### PR TITLE
chore(deps): patch update @types/jest to v27.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1021,9 +1021,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
-      "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
+      "version": "27.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz",
+      "integrity": "sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==",
       "dev": true,
       "requires": {
         "jest-diff": "^27.0.0",
@@ -2046,9 +2046,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "27.0.6",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
-      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
+      "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
       "dev": true
     },
     "dir-glob": {
@@ -3562,15 +3562,15 @@
       }
     },
     "jest-diff": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.3.1.tgz",
-      "integrity": "sha512-PCeuAH4AWUo2O5+ksW4pL9v5xJAcIKPUPfIhZBcG1RKv/0+dvaWTQK1Nrau8d67dp65fOqbeMdoil+6PedyEPQ==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.2.tgz",
+      "integrity": "sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.0.6",
-        "jest-get-type": "^27.3.1",
-        "pretty-format": "^27.3.1"
+        "diff-sequences": "^27.4.0",
+        "jest-get-type": "^27.4.0",
+        "pretty-format": "^27.4.2"
       }
     },
     "jest-docblock": {
@@ -3651,9 +3651,9 @@
       }
     },
     "jest-get-type": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.3.1.tgz",
-      "integrity": "sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.4.0.tgz",
+      "integrity": "sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==",
       "dev": true
     },
     "jest-haste-map": {
@@ -4885,21 +4885,21 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.3.1.tgz",
-      "integrity": "sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
+      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.2.5",
+        "@jest/types": "^27.4.2",
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.2.5",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
-          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+          "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@jest/types": "27.0.6",
     "@tsconfig/node12": "1.0.9",
-    "@types/jest": "27.0.2",
+    "@types/jest": "27.0.3",
     "@types/node": "12.20.15",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "eslint": "8.3.0",


### PR DESCRIPTION
This PR updates these packages:

|package|type|current version|new version|
|---|---|---|---|
|[@types/jest](https://www.npmjs.com/package/@types/jest)|patch|`27.0.2`|`27.0.3`|

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.10.0