### PR TITLE
chore(deps): minor update eslint-plugin-promise to v5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2563,9 +2563,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.1.tgz",
-      "integrity": "sha512-XgdcdyNzHfmlQyweOPTxmc7pIsS6dE4MvwhXWMQ2Dxs1XAL2GJDilUsjWen6TWik0aSI+zD/PqocZBblcm9rdA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
+      "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
       "dev": true
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-jest": "25.3.0",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-promise": "5.1.1",
+    "eslint-plugin-promise": "5.2.0",
     "husky": "7.0.4",
     "jest": "27.0.6",
     "lint-staged": "12.1.2",


### PR DESCRIPTION
This PR updates these packages:

|package|type|current version|new version|
|---|---|---|---|
|[eslint-plugin-promise](https://www.npmjs.com/package/eslint-plugin-promise)|minor|`5.1.1`|`5.2.0`|

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v0.10.0